### PR TITLE
Improve error handling and remove placeholders

### DIFF
--- a/todo.txt
+++ b/todo.txt
@@ -36,3 +36,4 @@
 - Automatische Tests über GitHub Actions eingerichtet
 - pre-commit mit black und ruff ergänzt
 - Skript für ausführbares Paket erstellt
+- Fehlerbehandlung verbessert und Platzhalter entfernt

--- a/videobatch_launcher.py
+++ b/videobatch_launcher.py
@@ -158,8 +158,12 @@ def main():
                     try:
                         sp.check_call(["sudo", "apt", "update"])
                         sp.check_call(["sudo", "apt", "install", "-y", "ffmpeg"])
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        QtWidgets.QMessageBox.warning(
+                            self,
+                            "FFmpeg",
+                            f"Installation fehlgeschlagen:\n{e}",
+                        )
                 self.ffmpeg_ok = shutil.which("ffmpeg") and shutil.which("ffprobe")
 
             self.setEnabled(True)


### PR DESCRIPTION
## Summary
- add logging when probing media duration and moving files fail
- wrap thumbnail creation in a context manager for safe cleanup
- surface FFmpeg installation errors in setup wizard
- ensure notes file exists and log FFmpeg progress parsing issues
- record completion in `todo.txt`

## Testing
- `pre-commit run --files videobatch_gui.py videobatch_launcher.py todo.txt`
- `python -m py_compile videobatch_gui.py videobatch_extra.py videobatch_launcher.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68932a5b32d08325a4db76958319af2c