### PR TITLE
refactor path handling and centralize CLI storage

### DIFF
--- a/config/paths.py
+++ b/config/paths.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from datetime import datetime
+from typing import Iterable
 
 BASE_DIR = Path.home() / ".videobatchtool"
 DATA_DIR = BASE_DIR / "data"
@@ -17,7 +18,7 @@ NOTES_FILE = BASE_DIR / "notes.txt"
 LOG_FILE = LOG_DIR / f"{datetime.now().strftime('%Y%m%d-%H%M%S')}.log"
 PROJECT_DB = DATA_DIR / "autosave.db"
 
-for d in (
+_DIRS: tuple[Path, ...] = (
     DATA_DIR,
     CONFIG_DIR,
     LOG_DIR,
@@ -25,5 +26,26 @@ for d in (
     HELP_DIR,
     USED_DIR,
     DEFAULT_OUT_DIR,
-):
-    d.mkdir(parents=True, exist_ok=True)
+)
+
+
+def ensure_directories(dirs: Iterable[Path] = _DIRS) -> None:
+    """Benötigte Ordner anlegen (Directory Creation)."""
+    for d in dirs:
+        d.mkdir(parents=True, exist_ok=True)
+
+
+__all__ = [
+    "BASE_DIR",
+    "DATA_DIR",
+    "CONFIG_DIR",
+    "LOG_DIR",
+    "ARCHIVE_DIR",
+    "HELP_DIR",
+    "USED_DIR",
+    "DEFAULT_OUT_DIR",
+    "NOTES_FILE",
+    "LOG_FILE",
+    "PROJECT_DB",
+    "ensure_directories",
+]

--- a/proof.txt
+++ b/proof.txt
@@ -9,3 +9,4 @@
 - Automatische ffmpeg-Installation läuft nur über apt auf Linux; andere Systeme benötigen manuelle Einrichtung.
 - Neue CLI speichert Termine im Klartext ohne Eingabevalidierung oder Verschlüsselung.
 - iCal-Export überschreibt vorhandene Dateien ohne Rückfrage und speichert Termine im Klartext.
+- Globale SQLite-Verbindung und Cache in storage.py sind nicht threadsicher und können offene Handles hinterlassen.

--- a/roadmap.txt
+++ b/roadmap.txt
@@ -10,9 +10,10 @@
 - Sphinx-Dokumentation enthält eine Startanleitung.
 - Einfache CLI mit Hilfefunktion ergänzt.
 - CLI exportiert Termine als iCal-Datei.
+- Pfade werden erst bei Bedarf angelegt; CLI nutzt zentrale Pfade.
 
-- Nächster Schritt: Alarme ergänzen.
-- Danach: CalDAV-Synchronisation und Gruppen-Kalender umsetzen.
+- Nächster Schritt: SQLite-Verbindung threadsicher machen.
+- Danach: Alarme ergänzen und CalDAV-Synchronisation sowie Gruppen-Kalender umsetzen.
 
 1. Alarme für Termine implementieren.
 2. CalDAV-Synchronisation und Gruppen-Kalender entwickeln.

--- a/start_cli.py
+++ b/start_cli.py
@@ -8,11 +8,14 @@ from pathlib import Path
 from uuid import uuid4
 
 from storage import load_project, save_project, close
+from config.paths import PROJECT_DB, ensure_directories
 
-DB_PATH = Path("data/project.db")
+DB_PATH = PROJECT_DB
 
 
 def _load_events() -> tuple[list[dict[str, str]], dict]:
+    """Termine und Rohdaten laden (Datenbankabfrage)."""
+    ensure_directories()
     data = load_project(DB_PATH)
     return data.setdefault("events", []), data
 
@@ -87,7 +90,7 @@ def main() -> None:
     export_p.add_argument("file", help="Zieldatei, z.B. events.ics")
 
     args = parser.parse_args()
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ensure_directories()
     if args.cmd == "add":
         add_event(args.title, args.date)
     elif args.cmd == "list":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from start_cli import add_event, export_ical  # noqa: E402
 
 
 def test_export_creates_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr("start_cli.DB_PATH", tmp_path / "events.db")
     add_event("Feier", "2025-12-24")
     out = tmp_path / "events.ics"

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -11,7 +11,7 @@ from PySide6.QtCore import Qt  # noqa: E402
 from videobatch_gui import MainWindow, human_time, make_thumb, PairItem  # noqa: E402
 from utils import check_ffmpeg  # noqa: E402
 from storage import load_project  # noqa: E402
-from config.paths import DEFAULT_OUT_DIR  # noqa: E402
+from config.paths import DEFAULT_OUT_DIR, NOTES_FILE  # noqa: E402
 
 
 def test_human_time_gui():
@@ -128,7 +128,7 @@ def test_toggle_thumbnails(tmp_path):
 
 def test_notes_persist(tmp_path):
     os.environ["XDG_CONFIG_HOME"] = str(tmp_path)
-    notes_file = Path("/tmp/.videobatchtool/notes.txt")
+    notes_file = NOTES_FILE
     if notes_file.exists():
         notes_file.unlink()
     QtWidgets.QApplication.instance() or QtWidgets.QApplication([])

--- a/todo.txt
+++ b/todo.txt
@@ -69,3 +69,4 @@
 - Persistente Ablage auf SQLite migriert
 - Sphinx-Dokumentation vervollständigen
 - Moderne Oberfläche als Web-Frontend oder CLI/TUI mit Hilfefunktion
+- Verzeichnisse werden nicht mehr beim Import von config.paths angelegt; Erstellung erfolgt bei Bedarf

--- a/videobatch_gui.py
+++ b/videobatch_gui.py
@@ -37,6 +37,7 @@ from config.paths import (
     PROJECT_DB,
     DEFAULT_OUT_DIR,
     USED_DIR,
+    ensure_directories,
 )
 from storage import save_project, load_project, close as close_storage
 from help.tooltips import (
@@ -51,6 +52,9 @@ from help.tooltips import (
     TIP_UNDO,
     TIP_STOP,
 )
+
+# benötigte Verzeichnisse sicherstellen
+ensure_directories()
 
 # ---------- Logging & Persistenz ----------
 


### PR DESCRIPTION
## Summary
- add `ensure_directories` to avoid directory creation on import
- use shared `PROJECT_DB` in CLI and ensure directories before database access
- ensure directories before GUI logging and update tests for new path logic

## Testing
- `pre-commit run --files config/paths.py start_cli.py videobatch_gui.py tests/test_cli.py tests/test_gui.py proof.txt roadmap.txt todo.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689380c5878c83258c70b73851b24595