### PR TITLE
Add CalDAV sync with conflict detection

### DIFF
--- a/docs/groups.rst
+++ b/docs/groups.rst
@@ -1,0 +1,16 @@
+Gruppen und CalDAV-Synchronisation
+=================================
+
+Dieser Abschnitt beschreibt den Ablauf der Kalenderabgleiche.
+
+1. Termine erhalten beim Anlegen eine eindeutige Kennung (UID).
+2. Beim Synchronisieren wird der Kalender vom Server abgerufen
+   (``requests.get``) und mit ``icalendar`` eingelesen.
+3. Ereignisse werden anhand der UID verglichen.
+4. Abweichungen mit neuerem Zeitstempel (DTSTAMP) werden als Konflikt
+   gemeldet und nicht automatisch überschrieben.
+5. Die Funktion liefert eine Konfliktliste zurück, damit der Aufrufer
+   entscheiden kann, welche Version behalten wird.
+
+So bleibt der Gruppen-Kalender konsistent, ohne dass Änderungen
+verloren gehen.

--- a/docs/roadmap/proof.txt
+++ b/docs/roadmap/proof.txt
@@ -11,3 +11,4 @@
 - Uneinheitliche Namenskonventionen erschweren das Lesen des Codes.
 - Alarme unterstützen nur einfache Minuten-Offsets ohne Wiederholungen.
 - Logging nutzt keine Logrotation; Logdatei kann wachsen.
+- CalDAV-Synchronisation meldet Konflikte, führt sie aber nicht automatisch zusammen.

--- a/docs/roadmap/roadmap.txt
+++ b/docs/roadmap/roadmap.txt
@@ -24,6 +24,8 @@
  - SQLite-Verbindung ist jetzt threadsicher.
  - Alarme für Termine hinzugefügt.
  - Nächster Schritt: Gruppen-Kalender und CalDAV-Synchronisation umsetzen.
+ - Dauerhafte UID pro Termin und CalDAV-Abgleich mit Konflikterkennung.
+ - Nächster Schritt: Konflikte automatisch auflösen und in die GUI integrieren.
 
- 1. Kalender- und CalDAV-Funktionen entwickeln.
+ 1. Kalender- und CalDAV-Funktionen weiterentwickeln.
  2. Gruppen-Kalender verbessern.

--- a/docs/roadmap/todo.txt
+++ b/docs/roadmap/todo.txt
@@ -2,8 +2,8 @@
 
 ## Offene Aufgaben
 // Architektur & Erweiterungen
-- Gruppen-Kalender und CalDAV-Synchronisation umsetzen
-- Kalenderfunktionen: vollständige iCal-Unterstützung, Gruppen-Kalender und CalDAV-Synchronisation
+- Konflikte bei CalDAV-Synchronisation automatisch auflösen
+- Kalenderfunktionen: vollständige iCal-Unterstützung und Gruppen-Kalender
 - Logrotation für das zentrale Logging ergänzen
 
 ## Erledigte Aufgaben
@@ -39,6 +39,7 @@
 - Ausgaben von FFmpeg unterdrückt, spart Speicher
 - requirements.txt und pyproject.toml angelegt
 - Alarme für Termine ergänzen
+- Persistente UID und CalDAV-Konfliktprüfung implementiert
 - Lizenzdatei hinzugefügt
 - Gemeinsame Hilfsfunktionen in utils.py ausgelagert (Modularisierung)
 - README mit Installationshinweisen erweitert

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Pillow==11.3.0
 PyInstaller==6.15.0
 PySide6==6.9.1
 pytest==8.4.1
+requests==2.32.3
+icalendar==5.0.12

--- a/start_cli.py
+++ b/start_cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from uuid import uuid4
 
 import logging
+import requests
+from icalendar import Calendar
 
 from storage import load_project, save_project, close
 from config.paths import PROJECT_DB, ensure_directories
@@ -35,7 +37,12 @@ def add_event(title: str, date_str: str, alarm: int | None = None) -> None:
         logger.error("Alarm muss eine positive Zahl sein.")
         return
     events, data = _load_events()
-    entry = {"title": title, "date": date.isoformat()}
+    entry = {
+        "uid": str(uuid4()),
+        "title": title,
+        "date": date.isoformat(),
+        "dtstamp": datetime.utcnow().isoformat(),
+    }
     if alarm is not None:
         entry["alarm"] = alarm
     events.append(entry)
@@ -65,13 +72,13 @@ def export_ical(file_path: Path) -> None:
         "VERSION:2.0",
         "PRODID:-//Kalendertool//DE",
     ]
-    stamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
     for ev in events:
         date = datetime.fromisoformat(ev["date"]).strftime("%Y%m%d")
+        stamp = datetime.fromisoformat(ev["dtstamp"]).strftime("%Y%m%dT%H%M%SZ")
         lines.extend(
             [
                 "BEGIN:VEVENT",
-                f"UID:{uuid4()}",
+                f"UID:{ev['uid']}",
                 f"DTSTAMP:{stamp}",
                 f"DTSTART;VALUE=DATE:{date}",
                 f"SUMMARY:{ev['title']}",
@@ -95,6 +102,60 @@ def export_ical(file_path: Path) -> None:
         logger.error("Export fehlgeschlagen: %s", exc)
         return
     logger.info("iCal-Datei unter %s erstellt", file_path)
+
+
+def sync_caldav(url: str) -> list[tuple[dict, dict]]:
+    """Kalender vom Server holen und mit lokalen Terminen abgleichen."""
+    events, data = _load_events()
+    local_by_uid = {ev["uid"]: ev for ev in events}
+    try:
+        resp = requests.get(url, timeout=5)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        logger.error("Kalender konnte nicht geladen werden: %s", exc)
+        return []
+    try:
+        cal = Calendar.from_ical(resp.text)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("Kalender konnte nicht gelesen werden: %s", exc)
+        return []
+    conflicts: list[tuple[dict, dict]] = []
+    for comp in cal.walk("VEVENT"):
+        uid = str(comp.get("UID"))
+        dtstamp = comp.get("DTSTAMP")
+        stamp = (
+            dtstamp.dt.isoformat()
+            if getattr(dtstamp, "dt", None) is not None
+            else datetime.utcnow().isoformat()
+        )
+        remote = {
+            "uid": uid,
+            "title": str(comp.get("SUMMARY")),
+            "date": comp.get("DTSTART").dt.isoformat(),
+            "dtstamp": stamp,
+        }
+        alarm = next((a for a in comp.subcomponents if a.name == "VALARM"), None)
+        if alarm is not None:
+            trig = alarm.get("TRIGGER")
+            if getattr(trig, "dt", None) is not None:
+                remote["alarm"] = int(abs(trig.dt.total_seconds()) // 60)
+        local = local_by_uid.get(uid)
+        if local:
+            local_stamp = local.get("dtstamp", "")
+            if stamp > local_stamp and (
+                local["title"] != remote["title"]
+                or local["date"] != remote["date"]
+                or local.get("alarm") != remote.get("alarm")
+            ):
+                conflicts.append((local, remote))
+            elif stamp > local_stamp:
+                local.update(remote)
+        else:
+            events.append(remote)
+    if conflicts:
+        return conflicts
+    save_project(data, DB_PATH)
+    return []
 
 
 def main() -> None:

--- a/storage.py
+++ b/storage.py
@@ -58,7 +58,7 @@ def load_project(db_path: Path) -> Dict[str, Any]:
         if row:
             _cache = json.loads(row[0])
         else:
-            _cache = {"pairs": [], "settings": {}}
+            _cache = {"pairs": [], "settings": {}, "events": []}
         _mtime = current_mtime
         return _cache
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,8 @@ import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from start_cli import add_event, export_ical  # noqa: E402
+from start_cli import add_event, export_ical, sync_caldav  # noqa: E402
+from storage import load_project, close  # noqa: E402
 
 
 def test_export_creates_file(tmp_path, monkeypatch):
@@ -17,3 +18,35 @@ def test_export_creates_file(tmp_path, monkeypatch):
     assert "SUMMARY:Feier" in content
     assert "BEGIN:VALARM" in content
     assert "TRIGGER:-PT30M" in content
+
+
+def test_sync_conflict(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    db = tmp_path / "events.db"
+    monkeypatch.setattr("start_cli.DB_PATH", db)
+    monkeypatch.setattr("start_cli.uuid4", lambda: "uid1")
+    close()
+    add_event("Meeting", "2025-01-01")
+    ics = (
+        "BEGIN:VCALENDAR\n"
+        "VERSION:2.0\n"
+        "BEGIN:VEVENT\n"
+        "UID:uid1\n"
+        "DTSTAMP:20300101T000000Z\n"
+        "DTSTART;VALUE=DATE:20250101\n"
+        "SUMMARY:Remote\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n"
+    )
+
+    class DummyResp:
+        text = ics
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr("requests.get", lambda url, timeout=5: DummyResp())
+    conflicts = sync_caldav("http://example.com/cal")
+    assert conflicts
+    data = load_project(db)
+    assert data["events"][0]["title"] == "Meeting"


### PR DESCRIPTION
## Summary
- persist unique UID and timestamp per event and use them for iCal export
- synchronize with CalDAV calendars and surface conflicts instead of overwriting
- document group sync flow and update roadmap and todo lists

## Testing
- `pre-commit run --files start_cli.py storage.py tests/test_cli.py docs/groups.rst docs/roadmap/proof.txt docs/roadmap/roadmap.txt docs/roadmap/todo.txt requirements.txt`
- `pytest tests/test_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6893ceec8edc8325bbcca810125c94c1